### PR TITLE
Chore(platform): Fixes for MSVC

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,27 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": []
+    }
+  ]
+}

--- a/cmake/settings.cmake
+++ b/cmake/settings.cmake
@@ -39,7 +39,13 @@ function(code_analysis TARGET VISIBILITY)
     endif()
 endfunction()
 
-if(NOT WIN32)
+# TODO(win):
+# - D9025: overriding '/MDd' with '/MTd'
+# - D9025: overriding '/W3' with '/W4'
+if(WIN32)
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif()

--- a/include/nova/intrinsics.h
+++ b/include/nova/intrinsics.h
@@ -1,0 +1,13 @@
+/**
+ * Part of Nova C++ Library.
+ * 
+ * Compiler magics, macros, instrinsics etc...
+ */
+
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+  #define NOVA_WIN
+#elif defined(__linux__)
+  #define NOVA_LINUX
+#elif defined(__APPLE__)
+  #define NOVA_MACOS
+#endif

--- a/include/nova/random.h
+++ b/include/nova/random.h
@@ -52,7 +52,12 @@ namespace detail {
 
 struct ascii_distribution {
     [[nodiscard]] char operator()(std::uniform_random_bit_generator auto& gen) {
-        return std::uniform_int_distribution(ascii::PrintableRange.low, ascii::PrintableRange.high)(gen);
+        return static_cast<char>(
+            std::uniform_int_distribution(
+                static_cast<int>(ascii::PrintableRange.low),
+                static_cast<int>(ascii::PrintableRange.high)
+            )(gen)
+        );
     }
 };
 

--- a/include/nova/utils.h
+++ b/include/nova/utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "nova/error.h"
+#include "nova/intrinsics.h"
 #include "nova/types.h"
 #include "nova/type_traits.h"
 
@@ -37,6 +38,12 @@ namespace ascii {
     }
     // NOLINTEND(*magic-numbers*)
 } // namespace ascii
+
+#if defined NOVA_WIN
+constexpr auto NewLine = "\r\n";
+#else
+constexpr auto NewLine = '\n';
+#endif
 
 /**
  * @brief   Return the current time in UNIX epoch

--- a/unit-tests/data.cc
+++ b/unit-tests/data.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "nova/data.h"
+#include "nova/utils.h"
 
 #include <array>
 #include <cstddef>
@@ -50,7 +51,10 @@ TEST(DataView, SubView) {
 
 TEST(DataView, ToHexString) {
     static constexpr auto data = "Hello Nova"sv;
-    EXPECT_EQ(fmt::format("{}", nova::data_view(data).to_hex()), "\n0000: 48 65 6c 6c 6f 20 4e 6f 76 61"sv);
+    EXPECT_EQ(
+        fmt::format("{}", nova::data_view(data).to_hex()),
+        fmt::format("{}0000: 48 65 6c 6c 6f 20 4e 6f 76 61", nova::NewLine)
+    );
 }
 
 TEST(DataView, ErrorOutOfBounds) {


### PR DESCRIPTION
- Added `intrinsics.h` with sensible macros for different platforms
- Added `NewLine` constant
- `std::uniform_int_distribution` doesn't like `char`