### PR TITLE
Refact!: return type as first parameter in `linspace`

### DIFF
--- a/include/nova/utils.h
+++ b/include/nova/utils.h
@@ -118,7 +118,7 @@ template <typename First, typename Second, typename ...Tail>
 /**
  * @brief   Generate evenly spaced numbers over the range.
  */
-template <typename T, std::floating_point R = float>
+template <std::floating_point R = float, typename T>
 [[nodiscard]] auto linspace(range<T> range, std::size_t num, bool inclusive = true) -> std::vector<R> {
     auto ret = std::vector<R>(num);
 

--- a/unit-tests/utils.cc
+++ b/unit-tests/utils.cc
@@ -95,6 +95,21 @@ TEST(Utils, Linspace) {
     );
 }
 
+TEST(Utils, Linspace_ExplicitReturnType) {
+    using namespace testing;
+
+    EXPECT_THAT(
+        nova::linspace<double>(nova::range<int>{ -2, 2 }, 5),
+        ElementsAre(
+            DoubleEq(-2.0),
+            DoubleEq(-1.0),
+            DoubleEq( 0.0),
+            DoubleEq( 1.0),
+            DoubleEq( 2.0)
+        )
+    );
+}
+
 TEST(Utils, Stopwatch_Elapsed) {
     auto stopwatch = nova::stopwatch();
     EXPECT_GT(stopwatch.elapsed(), 0ns);


### PR DESCRIPTION
The type of the `range<T>` is now the second type parameter. It will be implicit in most cases anyway.