### PR TITLE
Feat!: The one exception

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ if(CMAKE_BINARY_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     message(FATAL_ERROR "Building in-source is not supported! Create a build dir and remove ${CMAKE_SOURCE_DIR}/CMakeCache.txt")
 endif()
 
+option(BUILD_TESTS "Build tests" ON)
+option(NOVA_EXPERIMENTAL_FEATURE_SET "Enable experimental features that requires compiler/lib support" OFF)
+
 include(cmake/version.cmake)
 
 nova_extract_version()

--- a/cmake/settings.cmake
+++ b/cmake/settings.cmake
@@ -8,7 +8,12 @@ endif()
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(CMAKE_CXX_STANDARD 20)
+if(NOVA_EXPERIMENTAL_FEATURE_SET)
+    set(CMAKE_CXX_STANDARD 26)
+    add_compile_definitions(NOVA_EXPERIMENTAL_FEATURE_SET)
+else()
+    set(CMAKE_CXX_STANDARD 20)
+endif()
 
 if(COVERAGE)
     set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-g -O0 -fno-inline -fprofile-arcs -ftest-coverage")

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -19,6 +19,10 @@ target_link_libraries(nova INTERFACE
     project_warnings
 )
 
+if(NOVA_EXPERIMENTAL_FEATURE_SET)
+    target_link_libraries(nova INTERFACE stdc++exp)
+endif()
+
 target_include_directories(nova INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
     $<INSTALL_INTERFACE:include>

--- a/include/nova/error.hh
+++ b/include/nova/error.hh
@@ -11,24 +11,98 @@
 #include "nova/expected.hh"
 #include "nova/intrinsics.hh"
 
+#include <fmt/format.h>
+
 #include <cassert>
+#include <format>
+#include <source_location>
 #include <stdexcept>
 #include <string>
 
+#ifdef NOVA_EXPERIMENTAL_FEATURE_SET
+#include <stacktrace>
+#endif
+
 namespace nova {
 
-class assertion_error : public std::runtime_error {
+namespace detail {
+
+    class exception_base : public std::runtime_error {
+    public:
+        exception_base(
+            const std::string& msg,
+            const std::source_location& location
+        #ifdef NOVA_EXPERIMENTAL_FEATURE_SET
+            , const std::stacktrace& trace = std::stacktrace::current()
+        #endif
+        )
+            : std::runtime_error(msg)
+            , m_location(location)
+        #ifdef NOVA_EXPERIMENTAL_FEATURE_SET
+            , m_backtrace(trace)
+        #endif
+        {}
+
+        [[nodiscard]] auto where() const noexcept -> const std::source_location& { return m_location; }
+        #ifdef NOVA_EXPERIMENTAL_FEATURE_SET
+        [[nodiscard]] auto backtrace() const noexcept { return m_backtrace; }
+        #endif
+
+    protected:
+        std::source_location m_location;
+        #ifdef NOVA_EXPERIMENTAL_FEATURE_SET
+        std::stacktrace m_backtrace;
+        #endif
+
+    };
+
+} // namespace detail
+
+template <typename T>
+class exception : public detail::exception_base {
 public:
-    using std::runtime_error::runtime_error;
+    exception(
+        const std::string& msg,
+        const T& data,
+        const std::source_location& location = std::source_location::current()
+        #ifdef NOVA_EXPERIMENTAL_FEATURE_SET
+        , const std::stacktrace& trace = std::stacktrace::current()
+        #endif
+    )
+        : exception_base(
+            msg,
+            location
+            #ifdef NOVA_EXPERIMENTAL_FEATURE_SET
+            , trace
+            #endif
+        )
+        , m_data(data)
+    {}
+
+    [[nodiscard]] auto data() const noexcept -> const T& { return m_data; }
+
+private:
+    T m_data;
 };
 
-class parsing_error : public std::runtime_error {
+template <>
+class exception<void> : public detail::exception_base {
 public:
-    using std::runtime_error::runtime_error;
-};
-
-class not_implemented : public std::runtime_error {
-    using std::runtime_error::runtime_error;
+    exception(
+        const std::string& msg,
+        const std::source_location& location = std::source_location::current()
+        #ifdef NOVA_EXPERIMENTAL_FEATURE_SET
+        , const std::stacktrace& trace = std::stacktrace::current()
+        #endif
+    )
+        : exception_base(
+            msg,
+            location
+            #ifdef NOVA_EXPERIMENTAL_FEATURE_SET
+            , trace
+            #endif
+        )
+    {}
 };
 
 /**
@@ -36,6 +110,8 @@ class not_implemented : public std::runtime_error {
  */
 struct error {
     std::string message;
+
+    [[nodiscard]] auto operator<=>(const error&) const = default;
 };
 
 /**
@@ -64,10 +140,82 @@ struct error {
     #define nova_assert(expr)                                                   \
         if (not static_cast<bool>(expr)) {                                      \
             nova_breakpoint();                                                  \
-            throw nova::assertion_error("Assertion failed: " #expr);            \
+            throw nova::exception<void>("Assertion failed: " #expr);            \
         }
 #else
     // NOLINTNEXTLINE(cppcoreguidelines-macro-usage) | Must be a macro; `expr` needs to be converted to text
     #define nova_assert(expr) \
         assert(expr)
 #endif
+
+/**
+ * @brief   A convenience macro for throwing an exception.
+ *
+ * Useful for quick prototyping.
+ */
+#define THROWUP throw nova::exception<void>("ERROAR");
+
+template <>
+class fmt::formatter<std::source_location> {
+public:
+    constexpr auto parse(format_parse_context& ctx) {
+        return ctx.begin();
+    }
+
+    /**
+    * @example  nova/unit-tests/error.cc:7, from function `void func()`
+    */
+    template <typename FmtContext>
+    constexpr auto format(const std::source_location& loc, FmtContext& ctx) const {
+        return std::format_to(
+            ctx.out(),
+            "{}:{}, from function `{}`",
+            loc.file_name(),
+            loc.line(),
+            loc.function_name()
+        );
+    }
+};
+
+#ifdef NOVA_EXPERIMENTAL_FEATURE_SET
+template <>
+class fmt::formatter<std::stacktrace_entry> {
+public:
+    constexpr auto parse(format_parse_context& ctx) {
+        return ctx.begin();
+    }
+
+    template <typename FmtContext>
+    constexpr auto format(const std::stacktrace_entry& entry, FmtContext& ctx) const {
+        return std::format_to(
+            ctx.out(),
+            "{}:{} : {}",
+            entry.source_file(),
+            entry.source_line(),
+            entry.description()
+        );
+    }
+};
+
+template <>
+class fmt::formatter<std::stacktrace> {
+public:
+    constexpr auto parse(format_parse_context& ctx) {
+        return ctx.begin();
+    }
+
+    /**
+    * @example  nova/unit-tests/error.cc:8 : func()
+    *           nova/unit-tests/error.cc:13 : Error_Exception_Test::TestBody()
+    *
+    */
+    template <typename FmtContext>
+    constexpr auto format(const std::stacktrace& trace, FmtContext& ctx) const {
+        return std::format_to(
+            ctx.out(),
+            "{}",
+            fmt::format("{}", fmt::join(trace, "\n"))
+        );
+    }
+};
+#endif // NOVA_EXPERIMENTAL_FEATURE_SET

--- a/include/nova/json.hh
+++ b/include/nova/json.hh
@@ -67,7 +67,7 @@ public:
         : m_data(nlohmann::json::parse(content))
     {}
     catch (const nlohmann::json::exception& ex) {
-        throw parsing_error(ex.what());
+        throw exception<void>(ex.what());
     }
 
     [[nodiscard]] std::string dump(int indent = -1) const {

--- a/include/nova/system.hh
+++ b/include/nova/system.hh
@@ -79,7 +79,7 @@ inline auto set_cpu_affinity([[maybe_unused]] const process_scheduling& cfg) -> 
  * @brief   NOT IMPLEMENTED! It's a stub.
  */
 inline auto get_pid() -> int {
-    throw not_implemented("get_pid");
+    throw exception<void>("Not implemented");
 }
 
 // TODO: emit a non-error warning that every major compiler likes

--- a/include/nova/yaml.hh
+++ b/include/nova/yaml.hh
@@ -41,7 +41,7 @@ public:
         try {
             return m_doc.as<T>();
         } catch (const YAML::BadConversion& ex) {
-            throw nova::parsing_error(ex.what());
+            throw exception<void>(ex.what());
         }
     }
 
@@ -50,7 +50,7 @@ public:
         try {
             return lookup_impl(path).as<T>();
         } catch (const YAML::BadConversion& ex) {
-            throw nova::parsing_error(ex.what());
+            throw exception<void>(ex.what());
         }
     }
 
@@ -94,7 +94,7 @@ private:
 
             return node;
         } catch (const std::exception& ex) {
-            throw nova::parsing_error(ex.what());
+            throw exception<void>(ex.what());
         }
     }
 

--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -3,6 +3,7 @@ find_package(GTest REQUIRED)
 add_executable(test-nova
     color.cc
     data.cc
+    error.cc
     expected.cc
     flat_map.cc
     io.cc

--- a/unit-tests/error.cc
+++ b/unit-tests/error.cc
@@ -1,0 +1,53 @@
+#include "nova/error.hh"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <fmt/format.h>
+
+void func() {
+    THROWUP;
+}
+
+void func2() {
+    throw nova::exception("An error", nova::error{ "Some data" });
+}
+
+TEST(Error, ExceptionVoid) {
+    try {
+        func();
+        FAIL() << "Expected an exception to be thrown!";
+    } catch (const std::exception& ex) {
+        EXPECT_STREQ(ex.what(), "ERROAR");
+
+        const auto& nex = dynamic_cast<const nova::exception<void>&>(ex);
+        EXPECT_THAT(
+            fmt::format("{}", nex.where()),
+            testing::HasSubstr(
+                "nova/unit-tests/error.cc:8, from function `void func()`"
+            )
+        );
+
+#ifdef NOVA_EXPERIMENTAL_FEATURE_SET
+        EXPECT_THAT(
+            fmt::format("{}", nex.backtrace()),
+            testing::HasSubstr("error.cc")
+        );
+#endif
+    }
+}
+
+TEST(Error, ExceptionWithData) {
+    try {
+        func2();
+        FAIL() << "Expected an exception to be thrown!";
+    } catch (const nova::exception<nova::error>& ex) {
+        EXPECT_STREQ(ex.what(), "An error");
+
+        EXPECT_THAT(
+            fmt::format("{}", ex.where()),
+            testing::HasSubstr(
+                "nova/unit-tests/error.cc:12, from function `void func2()`"
+            )
+        );
+    }
+}

--- a/unit-tests/json.cc
+++ b/unit-tests/json.cc
@@ -41,11 +41,21 @@ TEST(Json, DomPath) {
 }
 
 TEST(Json, EmptyInput) {
-    EXPECT_THROW(std::ignore = nova::json(""), nova::parsing_error);
+    EXPECT_THAT(
+        []() { std::ignore = nova::json(""); },
+        testing::ThrowsMessage<nova::exception<void>>(
+            testing::HasSubstr("parse error at line 1, column 1: attempting to parse an empty input;")
+        )
+    );
 }
 
 TEST(Json, InvalidInput) {
-    EXPECT_THROW(std::ignore = nova::json(R"("key": 1)"), nova::parsing_error);
+    EXPECT_THAT(
+        []() { std::ignore = nova::json(R"("key": 1)"); },
+        testing::ThrowsMessage<nova::exception<void>>(
+            testing::HasSubstr("parse error at line 1, column 6: syntax error while parsing value - unexpected ':';")
+        )
+    );
 }
 
 TEST(Json, ConstructFromJsonObject) {

--- a/unit-tests/random.cc
+++ b/unit-tests/random.cc
@@ -4,6 +4,7 @@
 #include "nova/random.h"
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <array>
 #include <ranges>
@@ -93,11 +94,16 @@ TEST(Random, RandomString_AlphabeticDistribution) {
 }
 
 TEST(Random, LowLessThanEqualHigh_Int_Assertion) {
-    EXPECT_THROW(nova::random().number(nova::range<int>{ 3, 2 }), nova::assertion_error);
+    EXPECT_THAT(
+        []() { nova::random().number(nova::range<int>{ 3, 2 }); },
+        testing::ThrowsMessage<nova::exception<void>>(
+            testing::HasSubstr("Assertion failed: ")
+        )
+    );
 }
 
 TEST(Random, LowLessThanEqualHigh_FloatNan_Assertion) {
-    EXPECT_THROW(nova::random().number(nova::range<float>{ 3.0F, NAN }), nova::assertion_error);
-    EXPECT_THROW(nova::random().number(nova::range<float>{ NAN, 3.0F }), nova::assertion_error);
-    EXPECT_THROW(nova::random().number(nova::range<float>{ NAN,  NAN }), nova::assertion_error);
+    EXPECT_THROW(nova::random().number(nova::range<float>{ 3.0F, NAN }), nova::exception<void>);
+    EXPECT_THROW(nova::random().number(nova::range<float>{ NAN, 3.0F }), nova::exception<void>);
+    EXPECT_THROW(nova::random().number(nova::range<float>{ NAN,  NAN }), nova::exception<void>);
 }

--- a/unit-tests/yaml.cc
+++ b/unit-tests/yaml.cc
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "nova/error.h"
 #include "nova/yaml.h"
@@ -30,7 +31,13 @@ TEST(Yaml, FundamentalTypes) {
     EXPECT_FLOAT_EQ(doc.lookup<float>("float"), 9.9f);
     EXPECT_EQ(doc.lookup<bool>("bool"), true);
     EXPECT_EQ(doc.lookup<std::string>("root.key"), "string");
-    EXPECT_THROW(std::ignore = doc.lookup<int>("root.key"), nova::parsing_error);
+
+    EXPECT_THAT(
+        [&]() { std::ignore = doc.lookup<int>("root.key"); },
+        testing::ThrowsMessage<nova::exception<void>>(
+            testing::HasSubstr("error at line 1, column 1: bad conversion")
+        )
+    );
 }
 
 TEST(Yaml, Arrays) {


### PR DESCRIPTION
One exception class template with source location and with optional data.

- Added `NOVA_EXPERIMENTAL_FEATURE_SET` for features that not supported by all compiler vendors

BREAKING CHANGES:
- Exception type change in `json` constructor
- Exception type change in `yaml::lookup()`
- Exception type change in `get_pid()`