### PR TITLE
Feat!: Extended `data_view`

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.build import check_min_cppstd
 
 class Nova(ConanFile):
     name = "nova"
-    version = "0.1.3"
+    version = "0.1.4"
     package_type = "library"
 
     license = "BSL"

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.build import check_min_cppstd
 
 class Nova(ConanFile):
     name = "nova"
-    version = "0.1.4"
+    version = "0.2.0"
     package_type = "library"
 
     license = "BSL"

--- a/functional-tests/io.cc
+++ b/functional-tests/io.cc
@@ -76,8 +76,8 @@ namespace {
                 "Test failed!\n"
                 "Expected:{}\n"
                 "Actual: {}`",
-                nova::data_view(std::span(expected)).to_hex(),
-                nova::data_view(std::span(*file)).to_hex()
+                nova::data_view(std::span(expected)).as_hex_string(),
+                nova::data_view(std::span(*file)).as_hex_string()
             );
 
             return EXIT_FAILURE;

--- a/include/nova/data.hh
+++ b/include/nova/data.hh
@@ -3,18 +3,50 @@
 #include "nova/error.hh"
 
 #include <fmt/core.h>
-#include <spdlog/spdlog.h>
-#include <spdlog/fmt/bin_to_hex.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <span>
-#include <stdexcept>
+#include <string>
 #include <string_view>
 #include <type_traits>
+#include <vector>
 
+namespace nova::detail {
+
+    struct datacursor {
+        std::size_t pos;
+        std::size_t length;
+        std::size_t size;
+    };
+
+} // namespace nova::detail
+
+template <>
+class fmt::formatter<nova::detail::datacursor> {
+public:
+    constexpr auto parse(format_parse_context& ctx) {
+        return ctx.begin();
+    }
+
+    template <typename FmtContext>
+    constexpr auto format(const nova::detail::datacursor& cursor, FmtContext& ctx) const {
+        return fmt::format_to(
+            ctx.out(),
+            "Pos={} Len={} End={} (Size={})",
+            cursor.pos,
+            cursor.length,
+            cursor.pos + cursor.length,
+            cursor.size
+        );
+    }
+};
 namespace nova {
+
+using bytes = std::vector<std::byte>;
 
 template <typename T>
 concept binary_interpretable =
@@ -23,24 +55,15 @@ concept binary_interpretable =
     || std::is_same_v<T, std::uint8_t>
     || std::is_same_v<T, std::byte>;
 
-enum class endian {
+enum class endian : std::uint8_t {
     big,
     little,
-};
-
-class out_of_data_bounds : public std::out_of_range {
-public:
-    out_of_data_bounds(std::size_t pos, std::size_t length, std::size_t size)
-        : std::out_of_range(
-            fmt::format("Pos: {}, Len: {}, Size: {} (End: {})", pos, length, size, pos + length)
-        )
-    {}
 };
 
 namespace detail {
 
 /**
- * @brief   A binary data view on a range
+ * @brief   A binary data view on a range.
  *
  * Interprets binary data in a type safe manner either in big or little endian.
  *
@@ -55,43 +78,55 @@ class data_view {
     static constexpr auto Byte = 8;
 
 public:
-    [[nodiscard]] explicit
-    data_view(std::string_view data)
+
+    template <typename Range>
+        requires binary_interpretable<std::remove_cv_t<typename Range::value_type>>
+            and (
+                std::contiguous_iterator<typename Range::iterator>
+                or std::is_array_v<Range>
+            )
+    [[nodiscard]]
+    data_view(const Range& data)
         : m_data(std::as_bytes(std::span(data)))
     {}
 
-    template <typename T, std::size_t N>
-    [[nodiscard]] explicit
-    data_view(const std::array<T, N>& data)
-        : m_data(std::as_bytes(std::span<const T, N>(data)))
-    {}
-
-    template <binary_interpretable T>
     [[nodiscard]]
-    data_view(std::span<const T> data)
-        : m_data(std::as_bytes(data))
+    data_view(const void* ptr, std::size_t size)
+        : m_data(reinterpret_cast<const std::byte*>(ptr), size)
     {}
 
-    [[nodiscard]] data_view subview(std::size_t offset) {
+    [[nodiscard]] data_view subview(std::size_t offset) const {
         return data_view(m_data.subspan(offset));
     }
 
-    [[nodiscard]] std::size_t size() const {
-        return m_data.size();
+    [[nodiscard]] data_view subview(std::size_t offset, std::size_t length) const {
+        return data_view(m_data.subspan(offset, length));
     }
 
+    [[nodiscard]] auto begin() const { return std::begin(m_data); }
+    [[nodiscard]] auto begin()       { return std::begin(m_data); }
+    [[nodiscard]] auto end()   const { return std::end(m_data); }
+    [[nodiscard]] auto end()         { return std::end(m_data); }
+
+    [[nodiscard]] auto span()  const -> std::span<const std::byte> { return m_data; }
+    [[nodiscard]] auto empty() const -> bool                       { return m_data.empty(); }
+    [[nodiscard]] auto size()  const -> std::size_t                { return m_data.size(); }
+
+    [[nodiscard]] auto ptr()      const -> const std::byte* { return m_data.data(); }
+    [[nodiscard]] auto char_ptr() const -> const char*      { return reinterpret_cast<const char*>(m_data.data()); }
+
     /**
-     * @brief   Interpret data as number according to the type `T`
+     * @brief   Interpret data as number according to the type `T`.
      */
-    template <typename T>
+    template <typename T = std::size_t>
         requires std::is_integral_v<T>
-    [[nodiscard]] T as_number(std::size_t pos) const {
-        boundary_check(pos, sizeof(T));
+    [[nodiscard]] auto as_number(std::size_t pos, std::size_t length) const -> T {
+        boundary_check(pos, length);
 
         auto ret = T {};
-        for (std::size_t i = 0; i < sizeof(T); ++i) {
+        for (std::size_t i = 0; i < length; ++i) {
             if constexpr (Endianness == endian::big) {
-                ret |= static_cast<T>(std::to_integer<T>(m_data[pos + i]) << (sizeof(T) - i - 1) * Byte);
+                ret |= static_cast<T>(std::to_integer<T>(m_data[pos + i]) << (length - i - 1) * Byte);
             }
             else {
                 ret |= static_cast<T>(std::to_integer<T>(m_data[pos + i]) << i * Byte);
@@ -101,44 +136,67 @@ public:
     }
 
     /**
-     * @brief   Interpret data as a number, length specified dynamically
-     *
-     * Convenience function for hiding switch cases.
+     * @brief   Interpret data as number according to the type `T`.
      */
-    [[nodiscard]]
-    std::size_t as_number(std::size_t pos, std::uint8_t length) const {
-        switch (length) {
-            case 1:     return as_number<std::uint8_t>(pos);
-            case 2:     return as_number<std::uint16_t>(pos);
-            case 4:     return as_number<std::uint32_t>(pos);
-        }
-        throw std::domain_error("Invalid integer length");
+    template <typename T>
+        requires std::is_integral_v<T>
+    [[nodiscard]] auto as_number(std::size_t pos) const -> T {
+        return as_number<T>(pos, sizeof(T));
     }
 
     /**
      * @brief   Interpret data for the given `length` as a string
      */
     [[nodiscard]]
-    std::string_view as_string(std::size_t pos, std::size_t length) const {
+    auto as_string(std::size_t pos, std::size_t length) const -> std::string_view {
         boundary_check(pos, length);
         return { reinterpret_cast<const char*>(m_data.data() + pos), length };
     }
 
+    [[nodiscard]]
+    auto as_string() const -> std::string_view {
+        return as_string(0, size());
+    }
+
     /**
-     * @brief   Interpret data as dynamic length string
+     * @brief   Interpret data as dynamic length string.
      *
      * Length of the string is described in the first `length_bytes` bytes.
      */
     [[nodiscard]]
-    std::string_view as_dyn_string(std::size_t pos, std::uint8_t length_bytes = 1) const {
+    auto as_dyn_string(std::size_t pos, std::uint8_t length_bytes = 1) const -> std::string_view {
         const auto str_length = as_number(pos, length_bytes);
         boundary_check(pos, str_length);
         return as_string(pos + length_bytes, str_length);
     }
 
     [[nodiscard]]
-    auto to_hex() const {
-        return spdlog::to_hex(m_data);
+    auto as_hex_string(std::size_t pos, std::size_t length) const -> std::string {
+        std::string ret;
+
+        for (const auto& ch : m_data.subspan(pos, length)) {
+            ret += fmt::format("{:02x}", ch);
+        }
+
+        return ret;
+    }
+
+    [[nodiscard]]
+    auto as_hex_string() const -> std::string {
+        return as_hex_string(0, size());
+    }
+
+    [[nodiscard]]
+    auto to_vec() const -> bytes {
+        auto ret = bytes(size());
+
+        std::ranges::copy(
+            std::begin(m_data),
+            std::end(m_data),
+            std::begin(ret)
+        );
+
+        return ret;
     }
 
 private:
@@ -147,7 +205,7 @@ private:
     void boundary_check(std::size_t pos, std::size_t length) const {
         if constexpr (RuntimeBoundCheck) {
             if (size() < pos + length) {
-                throw out_of_data_bounds(pos, length, size());
+                throw exception("Out of bounds access: {}", detail::datacursor{ pos, length, size() });
             }
         }
         else {

--- a/include/nova/data.hh
+++ b/include/nova/data.hh
@@ -17,7 +17,7 @@
 
 namespace nova::detail {
 
-    struct datacursor {
+    struct data_cursor {
         std::size_t pos;
         std::size_t length;
         std::size_t size;
@@ -26,14 +26,14 @@ namespace nova::detail {
 } // namespace nova::detail
 
 template <>
-class fmt::formatter<nova::detail::datacursor> {
+class fmt::formatter<nova::detail::data_cursor> {
 public:
     constexpr auto parse(format_parse_context& ctx) {
         return ctx.begin();
     }
 
     template <typename FmtContext>
-    constexpr auto format(const nova::detail::datacursor& cursor, FmtContext& ctx) const {
+    constexpr auto format(const nova::detail::data_cursor& cursor, FmtContext& ctx) const {
         return fmt::format_to(
             ctx.out(),
             "Pos={} Len={} End={} (Size={})",
@@ -205,7 +205,7 @@ private:
     void boundary_check(std::size_t pos, std::size_t length) const {
         if constexpr (RuntimeBoundCheck) {
             if (size() < pos + length) {
-                throw exception("Out of bounds access: {}", detail::datacursor{ pos, length, size() });
+                throw exception("Out of bounds access: {}", detail::data_cursor{ pos, length, size() });
             }
         }
         else {

--- a/include/nova/nova.hh
+++ b/include/nova/nova.hh
@@ -31,4 +31,4 @@
 
 constexpr auto NovaVersionMajor = 0;
 constexpr auto NovaVersionMinor = 1;
-constexpr auto NovaVersionPatch = 3;
+constexpr auto NovaVersionPatch = 4;

--- a/include/nova/nova.hh
+++ b/include/nova/nova.hh
@@ -30,5 +30,5 @@
 #include <nova/yaml.h>
 
 constexpr auto NovaVersionMajor = 0;
-constexpr auto NovaVersionMinor = 1;
-constexpr auto NovaVersionPatch = 4;
+constexpr auto NovaVersionMinor = 2;
+constexpr auto NovaVersionPatch = 0;

--- a/unit-tests/data.cc
+++ b/unit-tests/data.cc
@@ -1,9 +1,10 @@
-#include <gtest/gtest.h>
+#include "nova/data.hh"
 
-#include "nova/data.h"
-#include "nova/utils.h"
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <array>
+#include <cstdint>
 #include <cstddef>
 #include <string_view>
 
@@ -25,7 +26,21 @@ TEST(DataView, FromArray) {
     EXPECT_EQ(view_le.as_number<std::uint16_t>(0), 513);
 }
 
-TEST(DataView, InterpretAsNumberIndexed) {
+TEST(DataView, FromPtr) {
+    static constexpr auto data = "blah";
+    const auto view = nova::data_view(data, 4);
+    EXPECT_EQ(view.as_string(), "blah"sv);
+}
+
+TEST(DataView, InterpretAsNumber_NonStdLength) {
+    static constexpr auto data = std::to_array<unsigned char>({ 0x00, 0x01, 0x02, 0x03 });
+    const auto view_be = nova::data_view(data);
+    const auto view_le = nova::data_view_le(data);
+    EXPECT_EQ(view_be.as_number(0, 3), 258);
+    EXPECT_EQ(view_le.as_number(0, 3), (2 << 16) + (1 << 8));
+}
+
+TEST(DataView, InterpretAsNumber_Indexed) {
     static constexpr auto data = std::to_array<unsigned char>({ 0x00, 0x01, 0x02 });
     const auto view_be = nova::data_view(data);
     const auto view_le = nova::data_view_le(data);
@@ -49,20 +64,37 @@ TEST(DataView, SubView) {
     EXPECT_EQ(nova::data_view(data).subview(3).as_number<std::uint8_t>(0), 4);
 }
 
+TEST(DataView, SubView_Length) {
+    static constexpr auto data = std::to_array<unsigned char>({ 0x01, 0x02, 0x03, 0x04, 0x05 });
+    EXPECT_EQ(nova::data_view(data).subview(3, 1).size(), 1);
+}
+
 TEST(DataView, ToHexString) {
     static constexpr auto data = "Hello Nova"sv;
     EXPECT_EQ(
-        fmt::format("{}", nova::data_view(data).to_hex()),
-        fmt::format("{}0000: 48 65 6c 6c 6f 20 4e 6f 76 61", nova::NewLine)
+        nova::data_view(data).as_hex_string(),
+        "48656c6c6f204e6f7661"
+    );
+}
+
+TEST(DataView, ToVec) {
+    static constexpr auto data = "\x00\x61"sv;
+    EXPECT_EQ(
+        nova::data_view(data).to_vec(),
+        ( std::vector<std::byte>{
+            std::byte { 0x00 },
+            std::byte { 0x61 }
+        } )
     );
 }
 
 TEST(DataView, ErrorOutOfBounds) {
     static constexpr auto data = std::to_array<unsigned char>({ 0x01, 0x02 });
-    try {
-        std::ignore = nova::data_view(data).as_number(1, 2);
-    }
-    catch (const nova::out_of_data_bounds& ex) {
-        EXPECT_EQ(ex.what(), "Pos: 1, Len: 2, Size: 2 (End: 3)"sv);
-    }
+
+    EXPECT_THAT(
+        []{ std::ignore = nova::data_view(data).as_number(1, 2); },
+        testing::ThrowsMessage<nova::exception>(
+            testing::HasSubstr("Out of bounds access: Pos=1 Len=2 End=3 (Size=2)")
+        )
+    );
 }


### PR DESCRIPTION
- Added generic constructor for any ranges.
- Added pointer and size constructor.
- Overloaded `subview()` with length.
- `const` correctness
- Support for non-standard length integers in `as_number()`.
- Added `to_vec()`.
- Added `bytes` alias.

BREAKING CHANGES:
- `to_hex()` superseded by `as_hex_string()`.
- Removed `out_of_data_bounds` exception type in favour of the generic `nova::exception` one.

Misc:
- Trailing return types.