### PR TITLE
Refact!: Various QoL improvements (from DSP branch)

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.build import check_min_cppstd
 
 class Nova(ConanFile):
     name = "nova"
-    version = "0.6.0"
+    version = "0.7.1"
     package_type = "library"
 
     license = "BSL"

--- a/examples/shielded.cc
+++ b/examples/shielded.cc
@@ -112,4 +112,4 @@ auto entrypoint([[maybe_unused]] auto args) -> int {
     return EXIT_SUCCESS;
 }
 
-MAIN(entrypoint);
+NOVA_MAIN(entrypoint);

--- a/functional-tests/io.cc
+++ b/functional-tests/io.cc
@@ -111,4 +111,4 @@ auto entrypoint([[maybe_unused]] auto args) -> int {
     return EXIT_FAILURE;
 }
 
-MAIN(entrypoint);
+NOVA_MAIN(entrypoint);

--- a/functional-tests/log.cc
+++ b/functional-tests/log.cc
@@ -62,4 +62,4 @@ auto entrypoint([[maybe_unused]] auto args) -> int {
     return EXIT_FAILURE;
 }
 
-MAIN(entrypoint);
+NOVA_MAIN(entrypoint);

--- a/include/nova/intrinsics.hh
+++ b/include/nova/intrinsics.hh
@@ -86,6 +86,23 @@ namespace nova {
     }
 #endif
 
+/**
+ * @brief   Invokes undefined behaviour for optimizing impossible code branches away.
+ *
+ * Available in C++23.
+ * - GCC 12
+ * - Clang 15
+ * - MSVC 19.32
+ * - Apple Clang 14.0.3
+ */
+[[noreturn]] inline void unreachable() {
+#if defined(NOVA_MSVC) && not defined(NOVA_CLANG)
+    __assume(false);
+#else
+    __builtin_unreachable();
+#endif
+}
+
 } // namespace nova
 
 #if defined(NOVA_MSVC)

--- a/include/nova/main.hh
+++ b/include/nova/main.hh
@@ -6,24 +6,35 @@
 
 #pragma once
 
+#include "nova/log.hh"
+
 #include <spdlog/spdlog.h>
 
+#include <cstdlib>
 #include <ranges>
 #include <string_view>
 #include <span>
 
-#define MAIN(func)                                                              \
+#define NOVA_MAIN(func)                                                         \
     int main(int argc, char* argv[]) {                                          \
         try {                                                                   \
             const auto args = std::span(argv, static_cast<std::size_t>(argc));  \
             return func(args | std::views::transform(                           \
                 [](const auto& x) { return std::string_view(x); })              \
             );                                                                  \
+        } catch (nova::exception& ex) {                                         \
+            nova::log::error(                                                   \
+                "Exception caught in main: {}\n{}\n",                           \
+                ex.what(),                                                      \
+                ex.where(),                                                     \
+                ex.backtrace()                                                  \
+            );                                                                  \
         } catch (std::exception& ex) {                                          \
-            spdlog::error("Exception caught in main: {}", ex.what());           \
+            nova::log::error("Exception caught in main: {}", ex.what());        \
         } catch (const char* msg) {                                             \
-            spdlog::error("Exception caught in main: {}", msg);                 \
+            nova::log::error("Exception caught in main: {}", msg);              \
         } catch (...) {                                                         \
-            spdlog::error("Unknown exception caught in main");                  \
+            nova::log::error("Unknown exception caught in main");               \
         }                                                                       \
+        return EXIT_FAILURE;                                                    \
     }

--- a/include/nova/nova.hh
+++ b/include/nova/nova.hh
@@ -32,4 +32,4 @@
 
 constexpr auto NovaVersionMajor = 0;
 constexpr auto NovaVersionMinor = 7;
-constexpr auto NovaVersionPatch = 0;
+constexpr auto NovaVersionPatch = 1;

--- a/include/nova/utils.hh
+++ b/include/nova/utils.hh
@@ -83,19 +83,19 @@ constexpr auto NewLine = '\n';
  */
 [[nodiscard]] inline
 std::chrono::nanoseconds now() {
-    return std::chrono::steady_clock().now().time_since_epoch();
+    return std::chrono::steady_clock::now().time_since_epoch();
 }
 
 /**
  * @brief   Convert a duration to seconds with fractional part.
  */
 [[nodiscard]] constexpr
-auto to_us(chrono_duration auto x) {
-    return static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(x).count());
+auto to_sec(chrono_duration auto x) {
+    return static_cast<double>(std::chrono::duration_cast<std::chrono::duration<double>>(x).count());
 }
 
 template <typename First>
-[[nodiscard]] consteval auto concat(First&& first) {
+[[nodiscard]] consteval auto concat(const First& first) {
     return first;
 }
 
@@ -189,7 +189,7 @@ public:
     /**
      * @brief   Measure the elapsed time since last call this function.
      */
-    auto lap() -> std::chrono::nanoseconds {
+    auto reset() -> std::chrono::nanoseconds {
         const auto time = now();
         const auto ret = time - m_clock;
         m_clock = time;

--- a/package-test/main.cc
+++ b/package-test/main.cc
@@ -2,9 +2,11 @@
 
 #include <cstdlib>
 
-int main() {
+auto entrypoint([[maybe_unused]] auto args) -> int {
     nova::log::init("Test");
-    spdlog::info("Nova version: v{}.{}.{}", NovaVersionMajor, NovaVersionMinor, NovaVersionPatch);
+    nova::log::info("Nova version: v{}.{}.{}", NovaVersionMajor, NovaVersionMinor, NovaVersionPatch);
 
     return EXIT_SUCCESS;
 }
+
+NOVA_MAIN(entrypoint);

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Version bumper tool
+# Automatically bumps version based on git tag.
+# Both in `nova.hh` and in `conanfile.py` files.
+#
+# Everything is patch bump unless "Feat".
+# The library is at major version 0, meaning breaking changes are not followed
+# in the versioning as the library is in experimental phase.
+
+set -euo pipefail
+
+version=$(sed --quiet 's/.*version = "\(.*\)"/\1/p' conanfile.py)
+v_major=$(cut -d '.' -f 1 <<< "${version}")
+v_minor=$(cut -d '.' -f 2 <<< "${version}")
+v_patch=$(cut -d '.' -f 3 <<< "${version}")
+
+echo "Previous version: ${version}"
+
+commit_tag=$(git show --format="%s" --quiet |cut -d ':' -f 1)
+
+if [[ "${commit_tag}" =~ F|feat ]]; then
+    v_minor=$((v_minor+1))
+else
+    v_patch=$((v_patch+1))
+fi
+
+bumped_version="${v_major}.${v_minor}.${v_patch}"
+echo "Bumped version: ${bumped_version}"
+
+sed --in-place \
+    -e "s/\(.*NovaVersionMajor = \).*;/\1${v_major};/" \
+    -e "s/\(.*NovaVersionMinor = \).*;/\1${v_minor};/" \
+    -e "s/\(.*NovaVersionPatch = \).*;/\1${v_patch};/" \
+    include/nova/nova.hh
+
+sed --in-place -e "s/\(.*version = \).*/\1\"${bumped_version}\"/" conanfile.py

--- a/unit-tests/utils.cc
+++ b/unit-tests/utils.cc
@@ -61,9 +61,9 @@ TEST(Utils, Now) {
     static_assert(std::is_same_v<T, std::chrono::nanoseconds>);
 }
 
-TEST(Utils, ToMicrosec) {
-    constexpr auto microsec = nova::to_us(9s);
-    EXPECT_EQ(microsec, 9'000'000.0);
+TEST(Utils, ToSec) {
+    constexpr auto sec = nova::to_sec(1566ms);
+    EXPECT_DOUBLE_EQ(sec, 1.566);
 }
 
 TEST(Utils, Concat) {
@@ -167,8 +167,8 @@ TEST(Utils, Stopwatch_Elapsed) {
 
 TEST(Utils, Stopwatch_Lap) {
     auto stopwatch = nova::stopwatch();
-    EXPECT_GE(stopwatch.lap(), 0ns);
+    EXPECT_GE(stopwatch.reset(), 0ns);
 
     std::this_thread::sleep_for(200ms);
-    EXPECT_GE(stopwatch.lap(), 200ms);
+    EXPECT_GE(stopwatch.reset(), 200ms);
 }


### PR DESCRIPTION
- "Main" macro now logs backtrace if supported.
- Added `nova::unreachable()`.

BREAKING CHANGES:
- `NOVA_MAIN` macro now returns with `EXIT_FAILURE` in case an exception.
- `nova::stopwatch::lap()` renamed to `nova::stopwatch::reset()`.

Fixes:
- `nova::to_us()` renamed to `nova::to_sec()` and is now correctly returns seconds with fractional part.

Misc:
- Added version bump tool to keep `nova.hh` and the Conanfile in sync.