### PR TITLE
Fix: `expected` now throws bad access for rvalues also

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.build import check_min_cppstd
 
 class Nova(ConanFile):
     name = "nova"
-    version = "0.7.2"
+    version = "0.7.3"
     package_type = "library"
 
     license = "BSL"

--- a/include/nova/data.hh
+++ b/include/nova/data.hh
@@ -30,8 +30,10 @@
 
 #include "nova/error.hh"
 #include "nova/type_traits.hh"
+#include "nova/utils.hh"
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <cassert>
@@ -687,3 +689,25 @@ private:
 };
 
 } // namespace nova
+
+template <>
+class fmt::formatter<nova::data_view> {
+public:
+    constexpr auto parse(format_parse_context& ctx) {
+        return ctx.begin();
+    }
+
+    template <typename FmtContext>
+    auto format(nova::data_view data, FmtContext& ctx) const {
+        if (is_printable(data)) {
+            return fmt::format_to(ctx.out(), "{}", data.as_string());
+        }
+        return fmt::format_to(ctx.out(), "x{}", data.as_hex_string());
+    }
+
+private:
+    [[nodiscard]] static auto is_printable(nova::data_view data) -> bool {
+        return not std::ranges::any_of(data, [](auto b) { return not nova::is_printable(b); });
+    }
+
+};

--- a/include/nova/error.hh
+++ b/include/nova/error.hh
@@ -181,3 +181,16 @@ public:
     }
 };
 #endif // NOVA_EXPERIMENTAL_FEATURE_SET
+
+template <>
+class fmt::formatter<nova::error> {
+public:
+    constexpr auto parse(format_parse_context& ctx) {
+        return ctx.begin();
+    }
+
+    template <typename FmtContext>
+    auto format(nova::error err, FmtContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", err.message);
+    }
+};

--- a/include/nova/expected.hh
+++ b/include/nova/expected.hh
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <nova/error.hh>
+
 #include <functional>
 #include <memory>
 #include <stdexcept>
@@ -134,40 +136,72 @@ public:
     [[nodiscard]] constexpr bool has_value() const noexcept         { return m_vex.value; }
     [[nodiscard]] constexpr explicit operator bool() const noexcept { return has_value(); }
 
-    [[nodiscard]] constexpr const T& value() const& {
-        if (not has_value()) {
-            // TODO(feat): throw the error type (feature depends on custom exception type)
-            throw std::runtime_error("Bad expected access");
-        }
-        return m_vex.impl.v;
-    }
-
-    [[nodiscard]] constexpr T& value() & {
-        if (not has_value()) {
-            // TODO(feat): throw the error type (feature depends on custom exception type)
-            throw std::runtime_error("Bad expected access");
-        }
-        return m_vex.impl.v;
-    }
-
     template <typename T2, typename E2>
     [[nodiscard]] friend constexpr bool operator==(const expected& lhs, const expected<T2, E2>& rhs) {
         return (
             lhs.has_value() and rhs.has_value()
-                and *lhs == * rhs
+                and *lhs == *rhs
             ) or (
             not lhs.has_value() and not rhs.has_value()
                 and lhs.error() == rhs.error()
         );
     }
 
-    [[nodiscard]] constexpr const T&& value() const&&               { return std::move(m_vex.impl.v); }
-    [[nodiscard]] constexpr       T&& value()      &&               { return std::move(m_vex.impl.v); }
+    [[nodiscard]] constexpr const T& value() const& {
+        if (not has_value()) {
+            throw exception("Bad expected access: it has no value");
+        }
+        return m_vex.impl.v;
+    }
 
-    [[nodiscard]] constexpr const E&  error() const&                { return m_vex.impl.e; }
-    [[nodiscard]] constexpr E&        error()      &                { return m_vex.impl.e; }
-    [[nodiscard]] constexpr const E&& error() const&&               { return std::move(m_vex.impl.e); }
-    [[nodiscard]] constexpr E&&       error()      &&               { return std::move(m_vex.impl.e); }
+    [[nodiscard]] constexpr T& value() & {
+        if (not has_value()) {
+            throw exception("Bad expected access: it has no value");
+        }
+        return m_vex.impl.v;
+    }
+
+    [[nodiscard]] constexpr const T&& value() const&& {
+        if (not has_value()) {
+            throw exception("Bad expected access: it has no value");
+        }
+        return std::move(m_vex.impl.v);
+    }
+
+    [[nodiscard]] constexpr T&& value() && {
+        if (not has_value()) {
+            throw exception("Bad expected access: it has no value");
+        }
+        return std::move(m_vex.impl.v);
+    }
+
+    [[nodiscard]] constexpr const E& error() const& {
+        if (has_value()) {
+            throw exception("Bad expected access: it has no error");
+        }
+        return m_vex.impl.e;
+    }
+
+    [[nodiscard]] constexpr E& error() & {
+        if (has_value()) {
+            throw exception("Bad expected access: it has no error");
+        }
+        return m_vex.impl.e;
+    }
+
+    [[nodiscard]] constexpr const E&& error() const&& {
+        if (has_value()) {
+            throw exception("Bad expected access: it has no error");
+        }
+        return std::move(m_vex.impl.e);
+    }
+
+    [[nodiscard]] constexpr E&& error() && {
+        if (has_value()) {
+            throw exception("Bad expected access: it has no error");
+        }
+        return std::move(m_vex.impl.e);
+    }
 
     template <typename U>
         requires std::is_copy_constructible_v<T>

--- a/include/nova/expected.hh
+++ b/include/nova/expected.hh
@@ -1,15 +1,20 @@
 /**
  * Part of Nova C++ Library.
  *
- * Reimplementatino of `std::expected` because not all compilers
- * support it yet.
+ * Reimplementation of `std::expected` because not all compilers support it
+ * yet.
  *
- * CAUTION: experimental and incomplete implementation!
+ * Error types must be formattable. In case of invalid access, an exception is
+ * thrown with a message provided by a formatter for the error type.
+ *
+ * `error()` access is checked, and it is not undefined behaviour (until C++26)
+ * to call it when there is no error.
  */
 
 #pragma once
 
 #include <nova/error.hh>
+#include <nova/type_traits.hh>
 
 #include <functional>
 #include <memory>
@@ -34,6 +39,7 @@ namespace detail {
 using detail::unexpect;
 
 template <typename T, typename E>
+    requires formattable<E>
 class expected;
 
 template <typename T>
@@ -54,6 +60,7 @@ struct unexpected {
 };
 
 template <typename T, typename E>
+    requires formattable<E>
 class expected {
 public:
     using value_type      = T;
@@ -149,28 +156,28 @@ public:
 
     [[nodiscard]] constexpr const T& value() const& {
         if (not has_value()) {
-            throw exception("Bad expected access: it has no value");
+            throw exception("Bad expected access: {}", error());
         }
         return m_vex.impl.v;
     }
 
     [[nodiscard]] constexpr T& value() & {
         if (not has_value()) {
-            throw exception("Bad expected access: it has no value");
+            throw exception("Bad expected access: {}", error());
         }
         return m_vex.impl.v;
     }
 
     [[nodiscard]] constexpr const T&& value() const&& {
         if (not has_value()) {
-            throw exception("Bad expected access: it has no value");
+            throw exception("Bad expected access: {}", error());
         }
         return std::move(m_vex.impl.v);
     }
 
     [[nodiscard]] constexpr T&& value() && {
         if (not has_value()) {
-            throw exception("Bad expected access: it has no value");
+            throw exception("Bad expected access: {}", error());
         }
         return std::move(m_vex.impl.v);
     }

--- a/include/nova/nova.hh
+++ b/include/nova/nova.hh
@@ -34,4 +34,4 @@
 
 constexpr auto NovaVersionMajor = 0;
 constexpr auto NovaVersionMinor = 7;
-constexpr auto NovaVersionPatch = 2;
+constexpr auto NovaVersionPatch = 3;

--- a/include/nova/parse.hh
+++ b/include/nova/parse.hh
@@ -300,12 +300,10 @@ public:
     constexpr auto format(nova::parse_error error, FmtContext& ctx) const {
         switch (error) {
             case nova::parse_error::invalid_argument:
-                fmt::format_to(ctx.out(), "Invalid argument");
-                break;
+                return fmt::format_to(ctx.out(), "Parse error (invalid argument)");
             case nova::parse_error::out_of_range:
-                fmt::format_to(ctx.out(), "Out of range");
-                break;
+                return fmt::format_to(ctx.out(), "Parse error (out of range)");
         }
-        return ctx.out();
+        nova::unreachable();
     }
 };

--- a/include/nova/parse.hh
+++ b/include/nova/parse.hh
@@ -299,9 +299,13 @@ public:
     template <typename FmtContext>
     constexpr auto format(nova::parse_error error, FmtContext& ctx) const {
         switch (error) {
-            case nova::parse_error::invalid_argument:   return "Invalid argument";
-            case nova::parse_error::out_of_range:       return "Out of range";
+            case nova::parse_error::invalid_argument:
+                fmt::format_to(ctx.out(), "Invalid argument");
+                break;
+            case nova::parse_error::out_of_range:
+                fmt::format_to(ctx.out(), "Out of range");
+                break;
         }
-        nova::unreachable();
+        return ctx.out();
     }
 };

--- a/include/nova/parse.hh
+++ b/include/nova/parse.hh
@@ -14,6 +14,8 @@
 #include "nova/intrinsics.hh"
 #include "nova/type_traits.hh"
 
+#include <fmt/format.h>
+
 #include <charconv>
 #include <cstdint>
 #include <limits>
@@ -286,3 +288,20 @@ template <typename R>
 }
 
 } // namespace nova
+
+template <>
+class fmt::formatter<nova::parse_error> {
+public:
+    constexpr auto parse(format_parse_context& ctx) {
+        return ctx.begin();
+    }
+
+    template <typename FmtContext>
+    constexpr auto format(nova::parse_error error, FmtContext& ctx) const {
+        switch (error) {
+            case nova::parse_error::invalid_argument:   return "Invalid argument";
+            case nova::parse_error::out_of_range:       return "Out of range";
+        }
+        nova::unreachable();
+    }
+};

--- a/include/nova/type_traits.hh
+++ b/include/nova/type_traits.hh
@@ -13,6 +13,8 @@
 #include <type_traits>
 #include <vector>
 
+#include <fmt/format.h>
+
 namespace nova {
 
 // Dependent false
@@ -51,5 +53,10 @@ template <typename T> concept chrono_duration = is_chrono_duration_v<T>;
 template <typename T> concept vector_like = is_std_vector_v<T>;
 template <typename T> concept map_like = is_std_map_v<T>;
 template <typename T> concept string_like = std::is_convertible_v<T, std::string_view>;
+
+template <typename T>
+concept formattable = requires {
+    fmt::formatter<T>();
+};
 
 } // namespace nova

--- a/include/nova/utils.hh
+++ b/include/nova/utils.hh
@@ -63,6 +63,15 @@ constexpr auto NewLine = '\n';
 #endif
 
 /**
+ * @brief   Check if the byte is ASCII printable.
+ */
+[[nodiscard]] constexpr auto is_printable(std::byte b) -> bool {
+    constexpr auto r = ascii::PrintableRange;
+    const auto ch = std::to_integer<char>(b);
+    return r.low <= ch && ch <= r.high;
+}
+
+/**
  * @brief   Split a string by delimiter.
  *
  * @param str       Input string to split.
@@ -182,7 +191,7 @@ public:
     /**
      * @brief   Measure the elapsed time since construction.
      */
-    [[nodiscard]] auto elapsed() -> std::chrono::nanoseconds {
+    [[nodiscard]] auto elapsed() const -> std::chrono::nanoseconds {
         return now() - m_clock;
     }
 

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -19,8 +19,9 @@ echo "Previous version: ${version}"
 
 commit_tag=$(git show --format="%s" --quiet |cut -d ':' -f 1)
 
-if [[ "${commit_tag}" =~ F|feat ]]; then
+if [[ "${commit_tag}" =~ (F|feat) ]]; then
     v_minor=$((v_minor+1))
+    v_patch=0
 else
     v_patch=$((v_patch+1))
 fi

--- a/unit-tests/data.cc
+++ b/unit-tests/data.cc
@@ -141,6 +141,14 @@ TEST(DataView, DataLiteral) {
     EXPECT_EQ("\x00\x01\x02"_data.as_hex_string(), "000102");
 }
 
+TEST(DataView, Formatter) {
+    static constexpr auto data = "Hello Nova"sv;
+    EXPECT_EQ(fmt::format("{}", data), "Hello Nova");
+
+    static const auto bin = "\x00\x01\x02"_data;
+    EXPECT_EQ(fmt::format("{}", bin), "x000102");
+}
+
 TEST(DataView, ErrorOutOfBounds) {
     static constexpr auto data = std::to_array<unsigned char>({ 0x01, 0x02 });
 

--- a/unit-tests/expected.cc
+++ b/unit-tests/expected.cc
@@ -11,6 +11,11 @@
 #include <tuple>
 
 struct custom_error {
+    // P0960R3 is not implemented in Apple Clang
+    constexpr custom_error(int x)
+        : code(x)
+    {}
+
     int code;
 };
 

--- a/unit-tests/expected.cc
+++ b/unit-tests/expected.cc
@@ -43,7 +43,22 @@ TEST(Expected, TrivialTypes) {
 
 TEST(Expected, Value_SafeAccess) {
     constexpr auto x = nova::expected<int, int>(nova::unexpect, 8);
-    EXPECT_THROW(std::ignore = x.value(), std::runtime_error);
+    EXPECT_THROW(std::ignore = x.value(), nova::exception);
+
+    EXPECT_THROW(
+        ( std::ignore = nova::expected<int, int>(nova::unexpect, 8).value() ),
+        nova::exception
+    );
+}
+
+TEST(Expected, Error_SafeAccess) {
+    constexpr auto x = nova::expected<int, int>(8);
+    EXPECT_THROW(std::ignore = x.error(), nova::exception);
+
+    EXPECT_THROW(
+        ( std::ignore = nova::expected<int, int>(8).error() ),
+        nova::exception
+    );
 }
 
 TEST(Expected, NonTrivialTypes) {

--- a/unit-tests/parse.cc
+++ b/unit-tests/parse.cc
@@ -1,17 +1,24 @@
-#include <cstdint>
-#include <gtest/gtest.h>
-
 #include "nova/parse.hh"
 
+#include <gtest/gtest.h>
+
 #include <chrono>
+#include <cstdint>
+#include <limits>
 #include <string_view>
 
 using namespace std::chrono_literals;
 using namespace std::string_view_literals;
 
+TEST(Parse, ParseErrorFormatter) {
+    EXPECT_EQ(fmt::format("{}", nova::parse_error::invalid_argument), "Parse error (invalid argument)");
+    EXPECT_EQ(fmt::format("{}", nova::parse_error::out_of_range), "Parse error (out of range)");
+}
+
 TEST(Parse, Detail_SafeMultiply) {
-    EXPECT_EQ(nova::detail::safe_multiply<char>(1, 64).value(), 64);
-    EXPECT_EQ(nova::detail::safe_multiply<char>(2, 65).error(), nova::parse_error::out_of_range);
+    constexpr auto maxchar = std::numeric_limits<char>::max();
+    EXPECT_EQ(nova::detail::safe_multiply<char>(1, maxchar).value(), maxchar);
+    EXPECT_EQ(nova::detail::safe_multiply<char>(2, maxchar + 1).error(), nova::parse_error::out_of_range);
     EXPECT_EQ(nova::detail::safe_multiply<float>(3.40282347E+38F, 10).error(), nova::parse_error::out_of_range);
 }
 

--- a/unit-tests/test_utils.hh
+++ b/unit-tests/test_utils.hh
@@ -14,6 +14,11 @@
         [&](){ expr; },                                                        \
         testing::ThrowsMessage<nova::exception>(testing::StartsWith("Assertion failed: ")))
 
+#define EXPECT_THROWN_MESSAGE(expr, msg)                                       \
+    EXPECT_THAT(                                                               \
+        [&](){ expr; },                                                        \
+        testing::ThrowsMessage<nova::exception>(testing::ContainsRegex(msg)))
+
 /**
  * @brief   Non-trivial type.
  */

--- a/unit-tests/type_traits.cc
+++ b/unit-tests/type_traits.cc
@@ -23,7 +23,7 @@ public:
     }
 
     template <typename FmtContext>
-    auto format(custom_formattable x, FmtContext& ctx) const {
+    auto format([[maybe_unused]] custom_formattable x, FmtContext& ctx) const {
         return fmt::format_to(ctx.out(), "");
     }
 };

--- a/unit-tests/type_traits.cc
+++ b/unit-tests/type_traits.cc
@@ -10,6 +10,24 @@
 #include <type_traits>
 #include <vector>
 
+#include <fmt/format.h>
+
+struct non_formattable {};
+struct custom_formattable {};
+
+template <>
+class fmt::formatter<custom_formattable> {
+public:
+    constexpr auto parse(format_parse_context& ctx) {
+        return ctx.begin();
+    }
+
+    template <typename FmtContext>
+    auto format(custom_formattable x, FmtContext& ctx) const {
+        return fmt::format_to(ctx.out(), "");
+    }
+};
+
 TEST(TypeTraits, ChronoDuration) {
     static_assert(nova::is_chrono_duration_v<std::chrono::nanoseconds>);
 }
@@ -31,4 +49,10 @@ TEST(TypeTraits, StringLike) {
     static_assert(nova::string_like<char*>);
     static_assert(nova::string_like<std::string>);
     static_assert(nova::string_like<std::string_view>);
+}
+
+TEST(TypeTraits_Concepts, Formattable) {
+    static_assert(nova::formattable<int>);
+    static_assert(not nova::formattable<non_formattable>);
+    static_assert(nova::formattable<custom_formattable>);
 }


### PR DESCRIPTION
- `stopwatch::elapsed()` is now `const` correct.

Minor improvements:
- Added formatter for `data_view`.
  - Added "is ASCII printable".
- Added formatter for `parse_error`.