### PR TITLE
Fix: Correct stream buffer resizing

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.build import check_min_cppstd
 
 class Nova(ConanFile):
     name = "nova"
-    version = "0.7.3"
+    version = "0.7.4"
     package_type = "library"
 
     license = "BSL"

--- a/include/nova/nova.hh
+++ b/include/nova/nova.hh
@@ -34,4 +34,4 @@
 
 constexpr auto NovaVersionMajor = 0;
 constexpr auto NovaVersionMinor = 7;
-constexpr auto NovaVersionPatch = 3;
+constexpr auto NovaVersionPatch = 4;

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -19,7 +19,7 @@ echo "Previous version: ${version}"
 
 commit_tag=$(git show --format="%s" --quiet |cut -d ':' -f 1)
 
-if [[ "${commit_tag}" =~ (F|feat) ]]; then
+if [[ "${commit_tag}" =~ (F|f)eat ]]; then
     v_minor=$((v_minor+1))
     v_patch=0
 else

--- a/unit-tests/data.cc
+++ b/unit-tests/data.cc
@@ -240,7 +240,7 @@ TEST(Data, Identity_DataView_Serialization_BigEndian) {
 
 TEST(Data, StreamBuffer_LimitedSize) {
     EXPECT_THROWN_MESSAGE(
-        nova::stream_buffer{ static_cast<long>(std::numeric_limits<int>::max()) + 1 },
+        nova::stream_buffer{ static_cast<nova::stream_buffer<>::difference_type>(std::numeric_limits<int>::max()) + 1 },
         "Maximum buffer size.*is over the limit"
     );
 }


### PR DESCRIPTION
Vector's `resize()` overwrites data if only `reserve()` is used while the memory is not written via vector's API.

- Fixed regex in version bumber script.