### PR TITLE
Fix: `now()` and added YAML default lookup

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.build import check_min_cppstd
 
 class Nova(ConanFile):
     name = "nova"
-    version = "0.7.4"
+    version = "0.7.5"
     package_type = "library"
 
     license = "BSL"

--- a/include/nova/nova.hh
+++ b/include/nova/nova.hh
@@ -34,4 +34,4 @@
 
 constexpr auto NovaVersionMajor = 0;
 constexpr auto NovaVersionMinor = 7;
-constexpr auto NovaVersionPatch = 4;
+constexpr auto NovaVersionPatch = 5;

--- a/include/nova/utils.hh
+++ b/include/nova/utils.hh
@@ -89,10 +89,28 @@ constexpr auto NewLine = '\n';
 
 /**
  * @brief   Return the current time in UNIX epoch.
+ *
+ * It is usually not monotonic, i.e., system time can be changed (backwards).
  */
+template <typename T = std::chrono::nanoseconds>
 [[nodiscard]] inline
-std::chrono::nanoseconds now() {
-    return std::chrono::steady_clock::now().time_since_epoch();
+auto now() -> std::chrono::nanoseconds {
+    return std::chrono::duration_cast<T>(
+        std::chrono::system_clock::now().time_since_epoch()
+    );
+}
+
+/**
+ * @brief   Return the current time using a constant monotonic clock.
+ *
+ * Note: it is not necessarily UNIX epoch.
+ */
+template <typename T = std::chrono::nanoseconds>
+[[nodiscard]] inline
+auto steady_now() -> std::chrono::nanoseconds {
+    return std::chrono::duration_cast<T>(
+        std::chrono::steady_clock::now().time_since_epoch()
+    );
 }
 
 /**
@@ -181,25 +199,27 @@ template <std::floating_point R = float, typename T>
 
 /**
  * @brief   A simple stopwatch measuring in nanosecond resolution.
+ *
+ * Uses a constant monotonic clock.
  */
 class stopwatch {
 public:
     [[nodiscard]] stopwatch()
-        : m_clock(now())
+        : m_clock(steady_now())
     {}
 
     /**
      * @brief   Measure the elapsed time since construction.
      */
     [[nodiscard]] auto elapsed() const -> std::chrono::nanoseconds {
-        return now() - m_clock;
+        return steady_now() - m_clock;
     }
 
     /**
      * @brief   Measure the elapsed time since last call this function.
      */
     auto reset() -> std::chrono::nanoseconds {
-        const auto time = now();
+        const auto time = steady_now();
         const auto ret = time - m_clock;
         m_clock = time;
         return ret;

--- a/unit-tests/utils.cc
+++ b/unit-tests/utils.cc
@@ -59,6 +59,9 @@ TEST(Utils, Split_StdString) {
 TEST(Utils, Now) {
     using T = decltype(nova::now());
     static_assert(std::is_same_v<T, std::chrono::nanoseconds>);
+
+    EXPECT_GT(nova::now<std::chrono::seconds>().count(), 1750784367);   // Tue Jun 24 18:59:27 CEST 2025
+    EXPECT_GT(nova::steady_now<std::chrono::seconds>().count(), 0);
 }
 
 TEST(Utils, ToSec) {

--- a/unit-tests/yaml.cc
+++ b/unit-tests/yaml.cc
@@ -1,6 +1,8 @@
 #include "nova/error.hh"
 #include "nova/yaml.hh"
 
+#include "test_utils.hh"
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -28,7 +30,26 @@ TEST(Yaml, ConstructFromYamlObject) {
     EXPECT_EQ(inner.lookup<std::string>("key"), "string");
 }
 
-// TODO: stoi exception
+TEST(Yaml, MissingKey) {
+    const auto doc = nova::yaml(data);
+
+    EXPECT_THROWN_MESSAGE(
+        std::ignore = doc.lookup<int>("nonexistent"),
+        "Invalid `.*` in YAML document"
+    );
+
+    EXPECT_THROWN_MESSAGE(
+        std::ignore = doc.lookup<int>("nonexistent.again"),
+        "Invalid `.*` in YAML document"
+    );
+}
+
+TEST(Yaml, DefaultValueLookup) {
+    const auto doc = nova::yaml(data);
+    EXPECT_EQ(doc.lookup<int>("int", 6), 9);
+    EXPECT_EQ(doc.lookup<int>("noInt", 6), 6);
+}
+
 TEST(Yaml, FundamentalTypes) {
     const auto doc = nova::yaml(data);
 
@@ -38,11 +59,9 @@ TEST(Yaml, FundamentalTypes) {
     EXPECT_EQ(doc.lookup<bool>("bool"), true);
     EXPECT_EQ(doc.lookup<std::string>("root.key"), "string");
 
-    EXPECT_THAT(
-        [&]{ std::ignore = doc.lookup<int>("root.key"); },
-        testing::ThrowsMessage<nova::exception>(
-            testing::HasSubstr("error at line 1, column 1: bad conversion")
-        )
+    EXPECT_THROWN_MESSAGE(
+        std::ignore = doc.lookup<int>("root.key"),
+        "error at line 1, column 1: bad conversion"
     );
 }
 
@@ -51,6 +70,14 @@ TEST(Yaml, Arrays) {
     const auto array = doc.lookup<std::vector>("array");
     EXPECT_EQ(array[0].as<std::string>(), "elem1");
     EXPECT_EQ(array[1].as<std::string>(), "elem2");
+    EXPECT_EQ(doc.lookup<std::string>("array.0"), "elem1");
+    EXPECT_EQ(doc.lookup<std::string>("array.1"), "elem2");
+
+    EXPECT_THROWN_MESSAGE(
+        std::ignore = doc.lookup<std::string>("array.ba"),
+        "Invalid `.*` in YAML document"
+    );
+
     EXPECT_EQ(array[2].lookup<int>("elem3.inner"), 1);
     EXPECT_EQ(array[3].lookup<int>("inner1"), 2);
     EXPECT_EQ(array[3].lookup<int>("inner2"), 3);


### PR DESCRIPTION
- `now()` is now correctly returns with UNIX epoch
- Added `steady_now()` for constant monotonic clock.
  - Stopwatch requires steady clock to correctly "survive" for example daylight savings.

- Added YAML lookup with default value.
- Refined YAML error handling.
  - Better error message for missing keys (invalid path).