### PR TITLE
Feat: Bit packed data reading

### DIFF
--- a/include/nova/data.hh
+++ b/include/nova/data.hh
@@ -30,6 +30,8 @@
 
 #include "nova/error.hh"
 #include "nova/type_traits.hh"
+#include "nova/types.hh"
+#include "nova/units.hh"
 #include "nova/utils.hh"
 
 #include <fmt/core.h>
@@ -213,6 +215,9 @@ template <endian Endianness = endian::big, bool RuntimeBoundCheck = true>
 class data_view {
     static constexpr auto Byte = 8;
 
+    template <typename R>
+    using Measure = units::measure<units::data_volume, long long, R>;
+
 public:
 
     template <typename Range>
@@ -228,7 +233,7 @@ public:
 
     [[nodiscard]]
     data_view(const void* ptr, std::size_t size)
-        : m_data(reinterpret_cast<const std::byte*>(ptr), size)
+        : m_data(reinterpret_cast<const std::byte*>(ptr), size)                                     // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast) | Low-level code; it is safe to cast between `const char` and `std::byte`.
     {}
 
     [[nodiscard]] data_view subview(std::size_t offset) const {
@@ -249,14 +254,15 @@ public:
     [[nodiscard]] auto size()  const -> std::size_t                { return m_data.size(); }
 
     [[nodiscard]] auto ptr()      const -> const std::byte* { return m_data.data(); }
-    [[nodiscard]] auto char_ptr() const -> const char*      { return reinterpret_cast<const char*>(m_data.data()); }
+    [[nodiscard]] auto char_ptr() const -> const char*      { return reinterpret_cast<const char*>(m_data.data()); }    // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast) | Low-level code; it is safe to cast between `const char` and `std::byte`.
 
     /**
-     * @brief   Interpret data as number according to the type `T`.
+     * @brief   Interpret data as number specified by `length`.
      */
     template <typename T = std::size_t>
         requires std::is_integral_v<T>
     [[nodiscard]] auto as_number(std::size_t pos, std::size_t length) const -> T {
+        nova_assert(length <= sizeof(T));
         boundary_check(pos, length);
 
         auto ret = T {};
@@ -272,7 +278,56 @@ public:
     }
 
     /**
+     * @brief   Interpret bit-packed data as number specified by `length` from `pos`.
+     *
+     * Both `pos` and `length` represent bits.
+     * The overload `as_number(extent<units::measure<...>>)` offers specifying
+     * them in either bytes or bits.
+     *
+     * Note: Bit-packed deserialization is ONLY supported in big endian mode!
+     *
+     * Algorithm:
+     * - Extracts the byte-array (given by `pos` and `length`) into a single value.
+     * - Trailing rightmost) bits are shifted off.
+     * - ... TODO: Finish reviewing and fixing GPT's code.
+     */
+    template <typename T = std::size_t>
+        requires std::is_integral_v<T>
+             and std::is_unsigned_v<T>
+    [[nodiscard]] auto as_number_bit_packed(std::size_t pos, std::size_t length) const -> T {
+        static_assert(Endianness == endian::big);
+        nova_assert(length <= sizeof(T) * Byte);
+        boundary_check_bit(pos, length);
+
+        const std::size_t start_byte = pos / Byte;
+        const std::size_t end_bit = pos + length;
+        const std::size_t end_byte = (end_bit + 7) / Byte;
+
+        auto ret = T {};
+
+        for (std::size_t i = start_byte; i < end_byte; ++i) {
+            ret = static_cast<T>(ret << Byte);
+            ret |= std::to_integer<std::uint8_t>(m_data[i]);
+        }
+
+        const std::size_t trailing_bits = end_byte * Byte - end_bit;
+        ret = static_cast<T>(ret >> trailing_bits);
+
+        // TODO: Finish reviewing and fixing GPT's code.
+
+        // Mask out excess bits beyond length
+        if (length < sizeof(T) * Byte) {
+            T mask = static_cast<T>(1 << length) - 1;
+            ret &= mask;
+        }
+
+        return ret;
+    }
+
+    /**
      * @brief   Interpret data as number according to the type `T`.
+     *
+     * This is wrapper around `as_number(pos, len)`.
      */
     template <typename T>
         requires std::is_integral_v<T>
@@ -281,12 +336,55 @@ public:
     }
 
     /**
-     * @brief   Interpret data for the given `length` as a string
+     * @brief   Interpret data as number according to the type `T`.
+     */
+    template <typename T = std::size_t>
+        requires std::is_integral_v<T>
+    [[nodiscard]] auto as_number(extent<std::size_t> ex) const -> T {
+        return as_number(ex.pos, ex.len);
+    }
+
+    /**
+     * @brief   Interpret bit-packed data as number specified by
+     *          `extent<units::measure<...>>`.
+     *
+     * Position and length in `extent` does not need to have the same ratio.
+     *
+     * @param ex    The extent specifing the position and length. Both must
+     *              be a measure representing bits or bytes as an integral
+     *              type.
+     *
+     * @tparam T    Return type which must be an unsigned integer and
+     *              must be able to represent the requrested length.
+     * @tparam R1   Ratio for position in `extent`.
+     * @tparam R2   Ratio for length in `extent`.
+     *
+     * @example
+     *
+     * ```cpp
+     * const auto view = nova::data_view(...);
+     * view.as_number<std::size_t>(nova::extent{ 1_byte, 2_bit });
+     * ```
+     *
+     * Note: Bit-packed deserialization is ONLY supported in big endian mode!
+     */
+    template <typename T = std::size_t, typename R1, typename R2 = R1>
+        requires std::is_integral_v<T>
+             and std::is_unsigned_v<T>
+    [[nodiscard]] auto as_number(extent<Measure<R1>, Measure<R2>> ex) const -> T {
+        return as_number_bit_packed(
+            static_cast<std::size_t>(units::measure_cast<units::bits>(ex.pos).count()),
+            static_cast<std::size_t>(units::measure_cast<units::bits>(ex.len).count())
+        );
+    }
+
+    /**
+     * @brief   Interpret data for the given `length` as a string.
      */
     [[nodiscard]]
     auto as_string(std::size_t pos, std::size_t length) const -> std::string_view {
         boundary_check(pos, length);
-        return { reinterpret_cast<const char*>(m_data.data() + pos), length };
+        return { reinterpret_cast<const char*>(m_data.data() + pos), length };                      // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast) | Low-level code; it is safe to cast between `const char` and `std::byte`.
     }
 
     [[nodiscard]]
@@ -341,11 +439,28 @@ private:
     void boundary_check(std::size_t pos, std::size_t length) const {
         if constexpr (RuntimeBoundCheck) {
             if (size() < pos + length) {
-                throw exception("Out of bounds access: {}", detail::data_cursor{ pos, length, size() });
+                throw exception(
+                    "Out of bounds access: {}",
+                    detail::data_cursor{ pos, length, size() }
+                );
             }
         }
         else {
             nova_assert(pos + length <= size());
+        }
+    }
+
+    void boundary_check_bit(std::size_t pos, std::size_t length) const {
+        if constexpr (RuntimeBoundCheck) {
+            if (size() * Byte < pos + length) {
+                throw exception(
+                    "Out of bounds access: {} (bits)",
+                    detail::data_cursor{ pos, length, size() * Byte }
+                );
+            }
+        }
+        else {
+            nova_assert(pos + length <= size() * Byte);
         }
     }
 };

--- a/include/nova/error.hh
+++ b/include/nova/error.hh
@@ -100,7 +100,7 @@ struct error {
 #ifdef NOVA_RUNTIME_ASSERTIONS
     // NOLINTNEXTLINE(cppcoreguidelines-macro-usage) | Must be a macro; `expr` needs to be converted to text
     #define nova_assert(expr)                                                   \
-        if (not static_cast<bool>(expr)) {                                      \
+        if (not (expr)) {                                                       \
             nova_breakpoint();                                                  \
             throw nova::exception("Assertion failed: " #expr);                  \
         }

--- a/include/nova/types.hh
+++ b/include/nova/types.hh
@@ -8,4 +8,10 @@ struct range {
     T high;
 };
 
+template <typename T1, typename T2 = T1>
+struct extent {
+    T1 pos;
+    T2 len;
+};
+
 } // namespace nova

--- a/include/nova/units.hh
+++ b/include/nova/units.hh
@@ -599,7 +599,7 @@ operator%(const measure<Unit1, Rep1, Ratio1>& lhs, const measure<Unit2, Rep2, Ra
 // ------------------------------------==[ Helper Types ]==-----------------------------------------
 
 namespace constants {
-    constexpr auto bit = 8;
+    constexpr auto bits_per_byte = 8;
     constexpr auto kByte = 1024;
     constexpr auto MByte = kByte * 1024;
     constexpr auto GByte = MByte * 1024;
@@ -615,7 +615,7 @@ namespace constants {
  */
 using DefaultRepT = std::chrono::seconds::rep;
 
-using bits   = measure<data_volume, long long, std::ratio<1, constants::bit>>;
+using bits   = measure<data_volume, long long, std::ratio<1, constants::bits_per_byte>>;
 using bytes  = measure<data_volume, long long>;
 using kBytes = measure<data_volume, long long, std::ratio<constants::kByte>>;
 using MBytes = measure<data_volume, long long, std::ratio<constants::MByte>>;

--- a/unit-tests/data.cc
+++ b/unit-tests/data.cc
@@ -1,5 +1,9 @@
-#include "nova/data.hh"
+#define NOVA_RUNTIME_ASSERTIONS
+
 #include "test_utils.hh"
+
+#include "nova/data.hh"
+#include "nova/units.hh"
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
@@ -10,8 +14,10 @@
 #include <limits>
 #include <string>
 #include <string_view>
+#include <tuple>
 
 using namespace nova::literals;
+using namespace nova::units::literals;
 using namespace std::literals;
 
 TEST(CharTraitsByte, Compare) {
@@ -86,7 +92,10 @@ TEST(DataView, InterpretAsNumber_NonStdLength) {
     const auto view_be = nova::data_view(data);
     const auto view_le = nova::data_view_le(data);
     EXPECT_EQ(view_be.as_number(0, 3), 258);
+    EXPECT_EQ(view_be.as_number(nova::extent<std::size_t>{ 0, 3 }), 258);
     EXPECT_EQ(view_le.as_number(0, 3), (2 << 16) + (1 << 8));
+
+    EXPECT_ASSERTION_FAIL(std::ignore = view_be.as_number<std::uint8_t>(0, 2));
 }
 
 TEST(DataView, InterpretAsNumber_Indexed) {
@@ -95,6 +104,17 @@ TEST(DataView, InterpretAsNumber_Indexed) {
     const auto view_le = nova::data_view_le(data);
     EXPECT_EQ(view_be.as_number<std::uint16_t>(1), 258);
     EXPECT_EQ(view_le.as_number<std::uint16_t>(1), 513);
+}
+
+TEST(DataView, SignedNumbers) {
+    EXPECT_EQ(nova::data_view("\x01"sv).as_number<std::int8_t>(0), 1);
+    EXPECT_EQ(nova::data_view("\xFF"sv).as_number<std::int8_t>(0), -1);
+    EXPECT_EQ(nova::data_view("\x80"sv).as_number<std::int8_t>(0), -128);
+    EXPECT_EQ(nova::data_view("\x81"sv).as_number<std::int8_t>(0), -127);
+    EXPECT_EQ(nova::data_view("\x82"sv).as_number<std::int8_t>(0), -126);
+
+    EXPECT_EQ(nova::data_view("\x80\x00"sv).as_number<std::int16_t>(0), -32768);
+    EXPECT_EQ(nova::data_view("\x80\x01"sv).as_number<std::int16_t>(0), -32767);
 }
 
 TEST(DataView, InterpretAsString) {
@@ -106,6 +126,79 @@ TEST(DataView, InterpretAsString) {
 TEST(DataView, InterpretAsDynamicString) {
     static constexpr auto data = "\x04\x61\x62\x63\x64\x65"sv;
     EXPECT_EQ(nova::data_view(data).as_dyn_string(0), "abcd");
+}
+
+TEST(DataView, InterpretAsBitPackedNumber_OneByte) {
+    static constexpr auto data = std::to_array<unsigned char>({
+        0b1100'0001
+    });
+
+    const auto view = nova::data_view(data);
+
+    EXPECT_EQ(view.as_number_bit_packed(0, 1), 1);
+    EXPECT_EQ(view.as_number_bit_packed(0, 2), 3);
+
+    EXPECT_EQ(view.as_number_bit_packed(1, 1), 1);
+    EXPECT_EQ(view.as_number_bit_packed(1, 2), 2);
+
+    EXPECT_EQ(view.as_number_bit_packed(7, 1), 1);
+    EXPECT_EQ(view.as_number_bit_packed(3, 5), 1);
+}
+
+TEST(DataView, InterpretAsBitPackedNumber_ph) {
+    static constexpr auto data = std::to_array<unsigned char>({
+        0b1100'0001,
+        0b1010'0011
+    });
+    const auto view = nova::data_view(data);
+
+    // FIXME: Current result is `10` instead of `26`.
+    // EXPECT_EQ(view.as_number_bit_packed<std::uint8_t>(4, 8), 26);
+    EXPECT_EQ(view.as_number_bit_packed<std::uint16_t>(4, 8), 26);
+}
+
+TEST(DataView, InterpretAsBitPackedNumber_MultipleBytes) {
+    static constexpr auto data = std::to_array<unsigned char>({
+        0b1100'0001,
+        0b1010'0011
+    });
+
+    const auto view = nova::data_view(data);
+
+    EXPECT_EQ(view.as_number_bit_packed(8, 1), 1);
+    EXPECT_EQ(view.as_number_bit_packed(8, 3), 5);
+    EXPECT_EQ(view.as_number_bit_packed(8, 8), 163);
+
+    EXPECT_EQ(view.as_number_bit_packed(4, 4), 1);
+    EXPECT_EQ(view.as_number_bit_packed(4, 5), 3);
+    EXPECT_EQ(view.as_number_bit_packed(4, 12), 419);
+}
+
+TEST(DataView, InterpretAsBitPackedNumber_ExtentOverload) {
+    static constexpr auto data = std::to_array<unsigned char>({
+        0b1100'0001,
+        0b1010'0011,
+        0x02,
+        0x03,
+        0x04,
+        0x05,
+        0x06,
+        0x07
+    });
+
+    const auto view = nova::data_view(data);
+    constexpr auto byte_pos = nova::units::bytes{ 1 };
+    constexpr auto bit_pos = nova::units::bits{ 8 };
+    constexpr auto len = nova::units::bits { 3 };
+    const auto byte_extent = nova::extent{ byte_pos, len };
+    const auto bit_extent = nova::extent{ bit_pos, len };
+
+    EXPECT_EQ(view.as_number<std::size_t>(byte_extent), 5);
+    EXPECT_EQ(view.as_number<std::size_t>(bit_extent), 5);
+    EXPECT_EQ(view.as_number<std::size_t>(nova::extent{ 1_byte, 3_bit }), 5);
+
+    EXPECT_EQ(view.as_number<std::size_t>(nova::extent{ 6_byte, 2_byte }), 1543);
+    EXPECT_EQ(view.as_number<std::uint16_t>(6), 1543);
 }
 
 TEST(DataView, SubView) {
@@ -157,6 +250,26 @@ TEST(DataView, ErrorOutOfBounds) {
         []{ std::ignore = nova::data_view(data).as_number(1, 2); },
         testing::ThrowsMessage<nova::exception>(
             testing::HasSubstr("Out of bounds access: Pos=1 Len=2 End=3 (Size=2)")
+        )
+    );
+}
+
+TEST(DataView, ErrorOutOfBounds_Bit) {
+    static constexpr auto data = std::to_array<unsigned char>({
+        0b1100'0001
+    });
+
+    EXPECT_THAT(
+        []{ std::ignore = nova::data_view(data).as_number_bit_packed(0, 9); },
+        testing::ThrowsMessage<nova::exception>(
+            testing::HasSubstr("Out of bounds access: Pos=0 Len=9 End=9 (Size=8) (bits)")
+        )
+    );
+
+    EXPECT_THAT(
+        []{ std::ignore = nova::data_view(data).as_number_bit_packed(1, 8); },
+        testing::ThrowsMessage<nova::exception>(
+            testing::HasSubstr("Out of bounds access: Pos=1 Len=8 End=9 (Size=8) (bits)")
         )
     );
 }


### PR DESCRIPTION
- Added `nova::extent` and a function overload for `as_number()`.
- Added test cases for extracting signed numbers with `as_number()`.

Fix:
- Removing redundant `static_cast` in `nova_assert`. (Is it really redundant?)

Misc:
- Refined `as_number()` function documentation (dynamic length overload).
- Added `NOLINT`s for silencing clang diagnostics.
- Renamed `nova::units::constants::bit` to `bits_per_byte`.